### PR TITLE
Update runtime-library/README.md binary test name

### DIFF
--- a/runtime-library/README.md
+++ b/runtime-library/README.md
@@ -44,7 +44,7 @@ C/library level, not the build system level.
 ```
 cmake -GNinja -Bbuild .
 cmake --build build
-./build/bin/ireert_test
+./build/bin/iree_test
 ```
 
 If we run the above commands on macOS, we will get


### PR DESCRIPTION
```
zsh: no such file or directory: ./build/bin/ireert_test
```
The executable name is iree_test. Maybe the cmake target should be renamed to ireert_test (rt for runtime I suppose).